### PR TITLE
Build ld script as part of the static library

### DIFF
--- a/app/build.mk
+++ b/app/build.mk
@@ -29,8 +29,7 @@ LOCAL_LDFLAGS := \
     -Llibopencm3/lib \
     -lopencm3_stm32f1
 LOCAL_LINKER_FILE := \
-    $(LOCAL_DIR)/gcc.ld \
-    $(LOCAL_DIR)/../libpostform/postform.ld
+    $(LOCAL_DIR)/gcc.ld
 LOCAL_SRC := \
     $(LOCAL_DIR)/src/startup.cpp \
     $(LOCAL_DIR)/src/hal/systick.cpp \

--- a/libpostform/build.mk
+++ b/libpostform/build.mk
@@ -28,4 +28,6 @@ LOCAL_COMPILER := arm_clang
 LOCAL_ARFLAGS := -rcs
 LOCAL_EXPORTED_DIRS := \
 	$(LOCAL_DIR)/inc
+LOCAL_LINKER_FILE := \
+    $(LOCAL_DIR)/postform.ld
 include $(BUILD_STATIC_LIB)


### PR DESCRIPTION
By declaring the linker script extension for postform in the static
library we don't need to care in the application code about including
this ld script extension, making it easier to use.