### PR TITLE
Add size specifiers to libpostform

### DIFF
--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -56,6 +56,8 @@ int main() {
     LOG_INFO(&logger, "I am %d years old...", 28);
     LOG_WARNING(&logger, "Third string! With multiple %s and more numbers: %d", "args", -1124);
     LOG_ERROR(&logger, "Oh boy, error %d just happened", 234556);
+    char char_array[] = "123";
+    LOG_ERROR(&logger, "This is my char array: %s", char_array);
 
     // This log check what happens when we send something larger than 1024 bytes (buffer size)
     // It's also great to test the dummy zeroes, as it doesn't have any zeroes.

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -59,9 +59,7 @@ int main() {
     char char_array[] = "123";
     LOG_ERROR(&logger, "This is my char array: %s", char_array);
 
-    // This log check what happens when we send something larger than 1024 bytes (buffer size)
-    // It's also great to test the dummy zeroes, as it doesn't have any zeroes.
-    LOG_DEBUG(&logger, "%s", "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+    constexpr auto interned_string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
                              "Proin congue, libero vitae condimentum egestas, tortor metus "
                              "condimentum augue, in pretium dolor purus quis lectus. Aenean "
                              "nunc sapien, eleifend quis convallis ut, venenatis quis mauris. "
@@ -84,7 +82,10 @@ int main() {
                              "laoreet. Nullam dignissim vel ex vel molestie. Vestibulum id eleifend "
                              "metus. Curabitur malesuada condimentum augue ut molestie. Vivamus "
                              "pellentesque purus sed velit placerat ultricies. In ut erat diam. "
-                             "Suspendisse potenti.");
+                             "Suspendisse potenti."_intern;
+
+    LOG_DEBUG(&logger, "Now if I wanted to print a really long text I can use %%k: %k",
+              interned_string);
     systick.delay(SysTick::TICKS_PER_SECOND);
     iteration++;
   }

--- a/libpostform/build.mk
+++ b/libpostform/build.mk
@@ -24,7 +24,8 @@ LOCAL_SRC := \
     $(LOCAL_DIR)/src/rtt/raw_writer.cpp \
     $(LOCAL_DIR)/src/rtt/cobs_writer.cpp \
     $(LOCAL_DIR)/src/format_validator.cpp \
-    $(LOCAL_DIR)/src/macros.cpp
+    $(LOCAL_DIR)/src/macros.cpp \
+    $(LOCAL_DIR)/src/platform.cpp
 LOCAL_ARM_ARCHITECTURE := v7-m
 LOCAL_ARM_FPU := nofp
 LOCAL_COMPILER := arm_clang

--- a/libpostform/inc/postform/macros.h
+++ b/libpostform/inc/postform/macros.h
@@ -2,6 +2,9 @@
 #ifndef POSTFORM_MACROS_H_
 #define POSTFORM_MACROS_H_
 
+#define __POSTFORM_STRINGIFY(X) #X
+#define __POSTFORM_EXPAND_AND_STRINGIFY(X) __POSTFORM_STRINGIFY(X)
+
 //! Gets the 16th element passed to it
 #define POSTFORM_INTERNAL_INTERNAL_16TH(_1, _2, _3, _4, _5, _6, _7, _8, _9, \
                                         _10, _11, _12, _13, _14, _15, _16,  \

--- a/libpostform/inc/postform/types.h
+++ b/libpostform/inc/postform/types.h
@@ -1,0 +1,19 @@
+
+#ifndef POSTFORM_TYPES_H_
+#define POSTFORM_TYPES_H_
+
+namespace Postform {
+
+/**
+ * @brief Internal representation of an interned string.
+ *
+ * This is serialized as a pointer, instead of copying
+ * the whole string through the transport.
+ */
+struct InternedString {
+  const char* str;
+};
+
+}  // namespace Postform
+
+#endif  // POSTFORM_TYPES_H_

--- a/libpostform/postform.ld
+++ b/libpostform/postform.ld
@@ -16,10 +16,16 @@ SECTIONS
         __InternedErrorStart = .;
         *(.interned_strings.error)
         __InternedErrorEnd = .;
+        *(.interned_strings.user)
     }
 
     .postform_config 0 (INFO):
     {
         *(.postform_config)
+    }
+
+    .postform_platform_descriptors 0 (INFO):
+    {
+        *(.postform_platform_descriptors)
     }
 }

--- a/libpostform/src/format_validator.cpp
+++ b/libpostform/src/format_validator.cpp
@@ -7,12 +7,15 @@ static_assert(POSTFORM_VALIDATE_FORMAT("%s", ""));
 static_assert(POSTFORM_VALIDATE_FORMAT("%d", 2));
 static_assert(!POSTFORM_VALIDATE_FORMAT("%d", (const char*)123ull));
 static_assert(!POSTFORM_VALIDATE_FORMAT("%s", 123ull));
-static_assert(POSTFORM_VALIDATE_FORMAT("%s %u %u, %s", (const char*)123ull, 1ull, 1ull, ""));
-static_assert(POSTFORM_VALIDATE_FORMAT("%s %s %d, %u", "", (const char*)123ull, 2ll, 12ull));
+static_assert(POSTFORM_VALIDATE_FORMAT("%s %llu %llu, %s", (const char*)123ull, 1ull, 1ull, ""));
+static_assert(POSTFORM_VALIDATE_FORMAT("%s %s %lld, %llu", "", (const char*)123ull, 2ll, 12ull));
 static_assert(POSTFORM_VALIDATE_FORMAT("fsdgfds%%"));
 static_assert(!POSTFORM_VALIDATE_FORMAT("fsdgfds%s"));
 static_assert(!POSTFORM_VALIDATE_FORMAT("fsdgfds%a"));
 static_assert(POSTFORM_VALIDATE_FORMAT("%x", 12));
+
+
+static_assert(POSTFORM_VALIDATE_FORMAT("%d", -123));
 
 // Compile-time tests for the POSTFORM_ASSERT_FORMAT
 POSTFORM_ASSERT_FORMAT("%u %u", 2u, 1u);

--- a/libpostform/src/platform.cpp
+++ b/libpostform/src/platform.cpp
@@ -1,0 +1,13 @@
+
+#include "postform/utils.h"
+
+struct PostformPlaformDescription {
+    uint32_t char_size = sizeof(char);
+    uint32_t short_size = sizeof(short);
+    uint32_t int_size = sizeof(int);
+    uint32_t long_int_size = sizeof(long int);
+    uint32_t long_long_int_size = sizeof(long long int);
+};
+
+CLINKAGE __attribute__((section(".postform_platform_descriptors")))
+const PostformPlaformDescription _postform_platform_description;


### PR DESCRIPTION
Also:
  * Allow using interned strings as arguments.
  * Fix char* arguments.
  * Store platform configuration in ELF file (size of integers).