### PR TITLE
Host app - take log file as argument

### DIFF
--- a/app/src/host_main.cpp
+++ b/app/src/host_main.cpp
@@ -1,7 +1,9 @@
 
+#include <atomic>
+#include <cstdio>
+
 #include "postform/file_logger.h"
 #include "postform/config.h"
-#include <atomic>
 
 namespace Postform {
 uint64_t getGlobalTimestamp() {
@@ -14,8 +16,13 @@ DECLARE_POSTFORM_CONFIG(
   .timestamp_frequency = 1
 );
 
-int main() {
-  Postform::FileLogger logger { std::string { "test.log" } };
+int main(int argc, const char* argv[]) {
+  if (argc != 2) {
+    printf("Expected 2 arguments!\n");
+    return -1;
+  }
+
+  Postform::FileLogger logger { std::string { argv[1] } };
 
   uint32_t iteration = 0;
   for (uint32_t i = 0; i < 10; i++) {


### PR DESCRIPTION
Instead of forcing the path of the log gile to test.log, let's pass it
through the arguments of the command. We expect to have a single
argument (in addition to the command name).

Change-Id: Ie567fb5894d7e4b406b811728077454e3ca99f9f