### PR TITLE
Add missing format specifiers to postform_decoder

### DIFF
--- a/app/src/host_main.cpp
+++ b/app/src/host_main.cpp
@@ -35,6 +35,31 @@ int main(int argc, const char* argv[]) {
     LOG_ERROR(&logger, "Oh boy, error %d just happened", 234556);
     char char_array[] = "123";
     LOG_ERROR(&logger, "This is my char array: %s", char_array);
+    LOG_ERROR(&logger, "different unsigned sizes: %hhu, %hu, %u, %lu, %llu",
+        static_cast<unsigned char>(123),
+        static_cast<unsigned short>(43212),
+        static_cast<unsigned int>(123123123),
+        static_cast<unsigned long>(123123123),
+        static_cast<unsigned long long>(123123123));
+    LOG_ERROR(&logger, "different signed sizes: %hhd, %hd, %d, %ld, %lld",
+        static_cast<signed char>(-123),
+        static_cast<short>(-13212),
+        static_cast<int>(-123123123),
+        static_cast<long>(-123123123),
+        static_cast<long long>(-123123123));
+    LOG_ERROR(&logger, "different octal sizes: %hho, %ho, %o, %lo, %llo",
+        static_cast<unsigned char>(0123),
+        static_cast<unsigned short>(0123),
+        static_cast<unsigned int>(0123123),
+        static_cast<unsigned long>(0123123123),
+        static_cast<unsigned long long>(0123123123));
+    LOG_ERROR(&logger, "different hex sizes: %hhx, %hx, %x, %lx, %llx",
+        static_cast<unsigned char>(0xf3),
+        static_cast<unsigned short>(0x1321),
+        static_cast<unsigned int>(0x12341235),
+        static_cast<unsigned long>(0x12341234),
+        static_cast<unsigned long long>(0x1234567812345678));
+    LOG_ERROR(&logger, "Pointer %p", reinterpret_cast<void*>(0x12341234));
 
     constexpr auto interned_string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
                              "Proin congue, libero vitae condimentum egestas, tortor metus "

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -58,6 +58,31 @@ int main() {
     LOG_ERROR(&logger, "Oh boy, error %d just happened", 234556);
     char char_array[] = "123";
     LOG_ERROR(&logger, "This is my char array: %s", char_array);
+    LOG_ERROR(&logger, "different unsigned sizes: %hhu, %hu, %u, %lu, %llu",
+        static_cast<unsigned char>(123),
+        static_cast<unsigned short>(43212),
+        static_cast<unsigned int>(123123123),
+        static_cast<unsigned long>(123123123),
+        static_cast<unsigned long long>(123123123));
+    LOG_ERROR(&logger, "different signed sizes: %hhd, %hd, %d, %ld, %lld",
+        static_cast<signed char>(-123),
+        static_cast<short>(-13212),
+        static_cast<int>(-123123123),
+        static_cast<long>(-123123123),
+        static_cast<long long>(-123123123));
+    LOG_ERROR(&logger, "different octal sizes: %hho, %ho, %o, %lo, %llo",
+        static_cast<unsigned char>(0123),
+        static_cast<unsigned short>(0123),
+        static_cast<unsigned int>(0123123),
+        static_cast<unsigned long>(0123123123),
+        static_cast<unsigned long long>(0123123123));
+    LOG_ERROR(&logger, "different hex sizes: %hhx, %hx, %x, %lx, %llx",
+        static_cast<unsigned char>(0xf3),
+        static_cast<unsigned short>(0x1321),
+        static_cast<unsigned int>(0x12341235),
+        static_cast<unsigned long>(0x12341234),
+        static_cast<unsigned long long>(0x1234567812345678));
+    LOG_ERROR(&logger, "Pointer %p", reinterpret_cast<void*>(0x12341234));
 
     constexpr auto interned_string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
                              "Proin congue, libero vitae condimentum egestas, tortor metus "

--- a/expected_log.txt
+++ b/expected_log.txt
@@ -10,141 +10,241 @@
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 35[39m
 5.000000     [38;5;1mError      [39m: This is my char array: 123
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 37[39m
-6.000000     [38;5;2mDebug      [39m: Now if I wanted to print a really long text I can use %k: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin congue, libero vitae condimentum egestas, tortor metus condimentum augue, in pretium dolor purus quis lectus. Aenean nunc sapien, eleifend quis convallis ut, venenatis quis mauris. Morbi tempor, ex a lobortis luctus, sem nunc laoreet dolor, pellentesque gravida mauris risus nec est. Aliquam ante sapien, vehicula vel elementum at, feugiat quis libero. Nulla in lorem eu erat vulputate efficitur. Etiam dapibus purus sed sagittis lobortis. Sed quis porttitor nulla. Nulla in ante ac arcu semper efficitur ut at erat. Fusce porttitor suscipit augue. Donec vel lorem justo. Aenean id dolor quis erat blandit cursus. Aenean varius fringilla eros vitae vestibulum.
+6.000000     [38;5;1mError      [39m: different unsigned sizes: 123, 43212, 123123123, 123123123, 123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 43[39m
+7.000000     [38;5;1mError      [39m: different signed sizes: -123, -13212, -123123123, -123123123, -123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 49[39m
+8.000000     [38;5;1mError      [39m: different octal sizes: 123, 123, 123123, 123123123, 123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 55[39m
+9.000000     [38;5;1mError      [39m: different hex sizes: f3, 1321, 12341235, 12341234, 1234567812345678
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 61[39m
+10.000000    [38;5;1mError      [39m: Pointer 0x12341234
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 62[39m
+11.000000    [38;5;2mDebug      [39m: Now if I wanted to print a really long text I can use %k: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin congue, libero vitae condimentum egestas, tortor metus condimentum augue, in pretium dolor purus quis lectus. Aenean nunc sapien, eleifend quis convallis ut, venenatis quis mauris. Morbi tempor, ex a lobortis luctus, sem nunc laoreet dolor, pellentesque gravida mauris risus nec est. Aliquam ante sapien, vehicula vel elementum at, feugiat quis libero. Nulla in lorem eu erat vulputate efficitur. Etiam dapibus purus sed sagittis lobortis. Sed quis porttitor nulla. Nulla in ante ac arcu semper efficitur ut at erat. Fusce porttitor suscipit augue. Donec vel lorem justo. Aenean id dolor quis erat blandit cursus. Aenean varius fringilla eros vitae vestibulum.
 Morbi tristique tristique nulla, at posuere ex sagittis at. Aliquam est quam, porta nec erat ac, convallis tempus augue. Nam eu quam vulputate, luctus sapien vel, tristique arcu. Suspendisse et ultrices odio. Pellentesque consectetur lacus sapien, ut ornare odio sagittis vel. Cras molestie eros odio, vitae ullamcorper ante vestibulum non. Vestibulum facilisis diam vel condimentum gravida. Donec in odio sit amet metus aliquet pharetra ac in ante. Phasellus sit amet dui vehicula, tristique neque et, ullamcorper est. Integer ullamcorper risus in mattis laoreet. Nullam dignissim vel ex vel molestie. Vestibulum id eleifend metus. Curabitur malesuada condimentum augue ut molestie. Vivamus pellentesque purus sed velit placerat ultricies. In ut erat diam. Suspendisse potenti.
-[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 65[39m
-7.000000     [38;5;2mDebug      [39m: Iteration number: 1
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 90[39m
+12.000000    [38;5;2mDebug      [39m: Iteration number: 1
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 31[39m
-8.000000     [38;5;2mDebug      [39m: Is this nice or what?!
+13.000000    [38;5;2mDebug      [39m: Is this nice or what?!
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 32[39m
-9.000000     [38;5;3mInfo       [39m: I am 28 years old...
+14.000000    [38;5;3mInfo       [39m: I am 28 years old...
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 33[39m
-10.000000    [38;2;255;165;0mWarning    [39m: Third string! With multiple args and more numbers: -1124
+15.000000    [38;2;255;165;0mWarning    [39m: Third string! With multiple args and more numbers: -1124
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 34[39m
-11.000000    [38;5;1mError      [39m: Oh boy, error 234556 just happened
+16.000000    [38;5;1mError      [39m: Oh boy, error 234556 just happened
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 35[39m
-12.000000    [38;5;1mError      [39m: This is my char array: 123
+17.000000    [38;5;1mError      [39m: This is my char array: 123
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 37[39m
-13.000000    [38;5;2mDebug      [39m: Now if I wanted to print a really long text I can use %k: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin congue, libero vitae condimentum egestas, tortor metus condimentum augue, in pretium dolor purus quis lectus. Aenean nunc sapien, eleifend quis convallis ut, venenatis quis mauris. Morbi tempor, ex a lobortis luctus, sem nunc laoreet dolor, pellentesque gravida mauris risus nec est. Aliquam ante sapien, vehicula vel elementum at, feugiat quis libero. Nulla in lorem eu erat vulputate efficitur. Etiam dapibus purus sed sagittis lobortis. Sed quis porttitor nulla. Nulla in ante ac arcu semper efficitur ut at erat. Fusce porttitor suscipit augue. Donec vel lorem justo. Aenean id dolor quis erat blandit cursus. Aenean varius fringilla eros vitae vestibulum.
+18.000000    [38;5;1mError      [39m: different unsigned sizes: 123, 43212, 123123123, 123123123, 123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 43[39m
+19.000000    [38;5;1mError      [39m: different signed sizes: -123, -13212, -123123123, -123123123, -123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 49[39m
+20.000000    [38;5;1mError      [39m: different octal sizes: 123, 123, 123123, 123123123, 123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 55[39m
+21.000000    [38;5;1mError      [39m: different hex sizes: f3, 1321, 12341235, 12341234, 1234567812345678
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 61[39m
+22.000000    [38;5;1mError      [39m: Pointer 0x12341234
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 62[39m
+23.000000    [38;5;2mDebug      [39m: Now if I wanted to print a really long text I can use %k: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin congue, libero vitae condimentum egestas, tortor metus condimentum augue, in pretium dolor purus quis lectus. Aenean nunc sapien, eleifend quis convallis ut, venenatis quis mauris. Morbi tempor, ex a lobortis luctus, sem nunc laoreet dolor, pellentesque gravida mauris risus nec est. Aliquam ante sapien, vehicula vel elementum at, feugiat quis libero. Nulla in lorem eu erat vulputate efficitur. Etiam dapibus purus sed sagittis lobortis. Sed quis porttitor nulla. Nulla in ante ac arcu semper efficitur ut at erat. Fusce porttitor suscipit augue. Donec vel lorem justo. Aenean id dolor quis erat blandit cursus. Aenean varius fringilla eros vitae vestibulum.
 Morbi tristique tristique nulla, at posuere ex sagittis at. Aliquam est quam, porta nec erat ac, convallis tempus augue. Nam eu quam vulputate, luctus sapien vel, tristique arcu. Suspendisse et ultrices odio. Pellentesque consectetur lacus sapien, ut ornare odio sagittis vel. Cras molestie eros odio, vitae ullamcorper ante vestibulum non. Vestibulum facilisis diam vel condimentum gravida. Donec in odio sit amet metus aliquet pharetra ac in ante. Phasellus sit amet dui vehicula, tristique neque et, ullamcorper est. Integer ullamcorper risus in mattis laoreet. Nullam dignissim vel ex vel molestie. Vestibulum id eleifend metus. Curabitur malesuada condimentum augue ut molestie. Vivamus pellentesque purus sed velit placerat ultricies. In ut erat diam. Suspendisse potenti.
-[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 65[39m
-14.000000    [38;5;2mDebug      [39m: Iteration number: 2
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 90[39m
+24.000000    [38;5;2mDebug      [39m: Iteration number: 2
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 31[39m
-15.000000    [38;5;2mDebug      [39m: Is this nice or what?!
+25.000000    [38;5;2mDebug      [39m: Is this nice or what?!
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 32[39m
-16.000000    [38;5;3mInfo       [39m: I am 28 years old...
+26.000000    [38;5;3mInfo       [39m: I am 28 years old...
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 33[39m
-17.000000    [38;2;255;165;0mWarning    [39m: Third string! With multiple args and more numbers: -1124
+27.000000    [38;2;255;165;0mWarning    [39m: Third string! With multiple args and more numbers: -1124
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 34[39m
-18.000000    [38;5;1mError      [39m: Oh boy, error 234556 just happened
+28.000000    [38;5;1mError      [39m: Oh boy, error 234556 just happened
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 35[39m
-19.000000    [38;5;1mError      [39m: This is my char array: 123
+29.000000    [38;5;1mError      [39m: This is my char array: 123
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 37[39m
-20.000000    [38;5;2mDebug      [39m: Now if I wanted to print a really long text I can use %k: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin congue, libero vitae condimentum egestas, tortor metus condimentum augue, in pretium dolor purus quis lectus. Aenean nunc sapien, eleifend quis convallis ut, venenatis quis mauris. Morbi tempor, ex a lobortis luctus, sem nunc laoreet dolor, pellentesque gravida mauris risus nec est. Aliquam ante sapien, vehicula vel elementum at, feugiat quis libero. Nulla in lorem eu erat vulputate efficitur. Etiam dapibus purus sed sagittis lobortis. Sed quis porttitor nulla. Nulla in ante ac arcu semper efficitur ut at erat. Fusce porttitor suscipit augue. Donec vel lorem justo. Aenean id dolor quis erat blandit cursus. Aenean varius fringilla eros vitae vestibulum.
+30.000000    [38;5;1mError      [39m: different unsigned sizes: 123, 43212, 123123123, 123123123, 123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 43[39m
+31.000000    [38;5;1mError      [39m: different signed sizes: -123, -13212, -123123123, -123123123, -123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 49[39m
+32.000000    [38;5;1mError      [39m: different octal sizes: 123, 123, 123123, 123123123, 123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 55[39m
+33.000000    [38;5;1mError      [39m: different hex sizes: f3, 1321, 12341235, 12341234, 1234567812345678
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 61[39m
+34.000000    [38;5;1mError      [39m: Pointer 0x12341234
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 62[39m
+35.000000    [38;5;2mDebug      [39m: Now if I wanted to print a really long text I can use %k: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin congue, libero vitae condimentum egestas, tortor metus condimentum augue, in pretium dolor purus quis lectus. Aenean nunc sapien, eleifend quis convallis ut, venenatis quis mauris. Morbi tempor, ex a lobortis luctus, sem nunc laoreet dolor, pellentesque gravida mauris risus nec est. Aliquam ante sapien, vehicula vel elementum at, feugiat quis libero. Nulla in lorem eu erat vulputate efficitur. Etiam dapibus purus sed sagittis lobortis. Sed quis porttitor nulla. Nulla in ante ac arcu semper efficitur ut at erat. Fusce porttitor suscipit augue. Donec vel lorem justo. Aenean id dolor quis erat blandit cursus. Aenean varius fringilla eros vitae vestibulum.
 Morbi tristique tristique nulla, at posuere ex sagittis at. Aliquam est quam, porta nec erat ac, convallis tempus augue. Nam eu quam vulputate, luctus sapien vel, tristique arcu. Suspendisse et ultrices odio. Pellentesque consectetur lacus sapien, ut ornare odio sagittis vel. Cras molestie eros odio, vitae ullamcorper ante vestibulum non. Vestibulum facilisis diam vel condimentum gravida. Donec in odio sit amet metus aliquet pharetra ac in ante. Phasellus sit amet dui vehicula, tristique neque et, ullamcorper est. Integer ullamcorper risus in mattis laoreet. Nullam dignissim vel ex vel molestie. Vestibulum id eleifend metus. Curabitur malesuada condimentum augue ut molestie. Vivamus pellentesque purus sed velit placerat ultricies. In ut erat diam. Suspendisse potenti.
-[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 65[39m
-21.000000    [38;5;2mDebug      [39m: Iteration number: 3
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 90[39m
+36.000000    [38;5;2mDebug      [39m: Iteration number: 3
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 31[39m
-22.000000    [38;5;2mDebug      [39m: Is this nice or what?!
+37.000000    [38;5;2mDebug      [39m: Is this nice or what?!
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 32[39m
-23.000000    [38;5;3mInfo       [39m: I am 28 years old...
+38.000000    [38;5;3mInfo       [39m: I am 28 years old...
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 33[39m
-24.000000    [38;2;255;165;0mWarning    [39m: Third string! With multiple args and more numbers: -1124
+39.000000    [38;2;255;165;0mWarning    [39m: Third string! With multiple args and more numbers: -1124
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 34[39m
-25.000000    [38;5;1mError      [39m: Oh boy, error 234556 just happened
+40.000000    [38;5;1mError      [39m: Oh boy, error 234556 just happened
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 35[39m
-26.000000    [38;5;1mError      [39m: This is my char array: 123
+41.000000    [38;5;1mError      [39m: This is my char array: 123
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 37[39m
-27.000000    [38;5;2mDebug      [39m: Now if I wanted to print a really long text I can use %k: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin congue, libero vitae condimentum egestas, tortor metus condimentum augue, in pretium dolor purus quis lectus. Aenean nunc sapien, eleifend quis convallis ut, venenatis quis mauris. Morbi tempor, ex a lobortis luctus, sem nunc laoreet dolor, pellentesque gravida mauris risus nec est. Aliquam ante sapien, vehicula vel elementum at, feugiat quis libero. Nulla in lorem eu erat vulputate efficitur. Etiam dapibus purus sed sagittis lobortis. Sed quis porttitor nulla. Nulla in ante ac arcu semper efficitur ut at erat. Fusce porttitor suscipit augue. Donec vel lorem justo. Aenean id dolor quis erat blandit cursus. Aenean varius fringilla eros vitae vestibulum.
+42.000000    [38;5;1mError      [39m: different unsigned sizes: 123, 43212, 123123123, 123123123, 123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 43[39m
+43.000000    [38;5;1mError      [39m: different signed sizes: -123, -13212, -123123123, -123123123, -123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 49[39m
+44.000000    [38;5;1mError      [39m: different octal sizes: 123, 123, 123123, 123123123, 123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 55[39m
+45.000000    [38;5;1mError      [39m: different hex sizes: f3, 1321, 12341235, 12341234, 1234567812345678
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 61[39m
+46.000000    [38;5;1mError      [39m: Pointer 0x12341234
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 62[39m
+47.000000    [38;5;2mDebug      [39m: Now if I wanted to print a really long text I can use %k: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin congue, libero vitae condimentum egestas, tortor metus condimentum augue, in pretium dolor purus quis lectus. Aenean nunc sapien, eleifend quis convallis ut, venenatis quis mauris. Morbi tempor, ex a lobortis luctus, sem nunc laoreet dolor, pellentesque gravida mauris risus nec est. Aliquam ante sapien, vehicula vel elementum at, feugiat quis libero. Nulla in lorem eu erat vulputate efficitur. Etiam dapibus purus sed sagittis lobortis. Sed quis porttitor nulla. Nulla in ante ac arcu semper efficitur ut at erat. Fusce porttitor suscipit augue. Donec vel lorem justo. Aenean id dolor quis erat blandit cursus. Aenean varius fringilla eros vitae vestibulum.
 Morbi tristique tristique nulla, at posuere ex sagittis at. Aliquam est quam, porta nec erat ac, convallis tempus augue. Nam eu quam vulputate, luctus sapien vel, tristique arcu. Suspendisse et ultrices odio. Pellentesque consectetur lacus sapien, ut ornare odio sagittis vel. Cras molestie eros odio, vitae ullamcorper ante vestibulum non. Vestibulum facilisis diam vel condimentum gravida. Donec in odio sit amet metus aliquet pharetra ac in ante. Phasellus sit amet dui vehicula, tristique neque et, ullamcorper est. Integer ullamcorper risus in mattis laoreet. Nullam dignissim vel ex vel molestie. Vestibulum id eleifend metus. Curabitur malesuada condimentum augue ut molestie. Vivamus pellentesque purus sed velit placerat ultricies. In ut erat diam. Suspendisse potenti.
-[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 65[39m
-28.000000    [38;5;2mDebug      [39m: Iteration number: 4
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 90[39m
+48.000000    [38;5;2mDebug      [39m: Iteration number: 4
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 31[39m
-29.000000    [38;5;2mDebug      [39m: Is this nice or what?!
+49.000000    [38;5;2mDebug      [39m: Is this nice or what?!
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 32[39m
-30.000000    [38;5;3mInfo       [39m: I am 28 years old...
+50.000000    [38;5;3mInfo       [39m: I am 28 years old...
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 33[39m
-31.000000    [38;2;255;165;0mWarning    [39m: Third string! With multiple args and more numbers: -1124
+51.000000    [38;2;255;165;0mWarning    [39m: Third string! With multiple args and more numbers: -1124
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 34[39m
-32.000000    [38;5;1mError      [39m: Oh boy, error 234556 just happened
+52.000000    [38;5;1mError      [39m: Oh boy, error 234556 just happened
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 35[39m
-33.000000    [38;5;1mError      [39m: This is my char array: 123
+53.000000    [38;5;1mError      [39m: This is my char array: 123
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 37[39m
-34.000000    [38;5;2mDebug      [39m: Now if I wanted to print a really long text I can use %k: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin congue, libero vitae condimentum egestas, tortor metus condimentum augue, in pretium dolor purus quis lectus. Aenean nunc sapien, eleifend quis convallis ut, venenatis quis mauris. Morbi tempor, ex a lobortis luctus, sem nunc laoreet dolor, pellentesque gravida mauris risus nec est. Aliquam ante sapien, vehicula vel elementum at, feugiat quis libero. Nulla in lorem eu erat vulputate efficitur. Etiam dapibus purus sed sagittis lobortis. Sed quis porttitor nulla. Nulla in ante ac arcu semper efficitur ut at erat. Fusce porttitor suscipit augue. Donec vel lorem justo. Aenean id dolor quis erat blandit cursus. Aenean varius fringilla eros vitae vestibulum.
+54.000000    [38;5;1mError      [39m: different unsigned sizes: 123, 43212, 123123123, 123123123, 123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 43[39m
+55.000000    [38;5;1mError      [39m: different signed sizes: -123, -13212, -123123123, -123123123, -123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 49[39m
+56.000000    [38;5;1mError      [39m: different octal sizes: 123, 123, 123123, 123123123, 123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 55[39m
+57.000000    [38;5;1mError      [39m: different hex sizes: f3, 1321, 12341235, 12341234, 1234567812345678
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 61[39m
+58.000000    [38;5;1mError      [39m: Pointer 0x12341234
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 62[39m
+59.000000    [38;5;2mDebug      [39m: Now if I wanted to print a really long text I can use %k: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin congue, libero vitae condimentum egestas, tortor metus condimentum augue, in pretium dolor purus quis lectus. Aenean nunc sapien, eleifend quis convallis ut, venenatis quis mauris. Morbi tempor, ex a lobortis luctus, sem nunc laoreet dolor, pellentesque gravida mauris risus nec est. Aliquam ante sapien, vehicula vel elementum at, feugiat quis libero. Nulla in lorem eu erat vulputate efficitur. Etiam dapibus purus sed sagittis lobortis. Sed quis porttitor nulla. Nulla in ante ac arcu semper efficitur ut at erat. Fusce porttitor suscipit augue. Donec vel lorem justo. Aenean id dolor quis erat blandit cursus. Aenean varius fringilla eros vitae vestibulum.
 Morbi tristique tristique nulla, at posuere ex sagittis at. Aliquam est quam, porta nec erat ac, convallis tempus augue. Nam eu quam vulputate, luctus sapien vel, tristique arcu. Suspendisse et ultrices odio. Pellentesque consectetur lacus sapien, ut ornare odio sagittis vel. Cras molestie eros odio, vitae ullamcorper ante vestibulum non. Vestibulum facilisis diam vel condimentum gravida. Donec in odio sit amet metus aliquet pharetra ac in ante. Phasellus sit amet dui vehicula, tristique neque et, ullamcorper est. Integer ullamcorper risus in mattis laoreet. Nullam dignissim vel ex vel molestie. Vestibulum id eleifend metus. Curabitur malesuada condimentum augue ut molestie. Vivamus pellentesque purus sed velit placerat ultricies. In ut erat diam. Suspendisse potenti.
-[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 65[39m
-35.000000    [38;5;2mDebug      [39m: Iteration number: 5
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 90[39m
+60.000000    [38;5;2mDebug      [39m: Iteration number: 5
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 31[39m
-36.000000    [38;5;2mDebug      [39m: Is this nice or what?!
+61.000000    [38;5;2mDebug      [39m: Is this nice or what?!
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 32[39m
-37.000000    [38;5;3mInfo       [39m: I am 28 years old...
+62.000000    [38;5;3mInfo       [39m: I am 28 years old...
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 33[39m
-38.000000    [38;2;255;165;0mWarning    [39m: Third string! With multiple args and more numbers: -1124
+63.000000    [38;2;255;165;0mWarning    [39m: Third string! With multiple args and more numbers: -1124
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 34[39m
-39.000000    [38;5;1mError      [39m: Oh boy, error 234556 just happened
+64.000000    [38;5;1mError      [39m: Oh boy, error 234556 just happened
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 35[39m
-40.000000    [38;5;1mError      [39m: This is my char array: 123
+65.000000    [38;5;1mError      [39m: This is my char array: 123
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 37[39m
-41.000000    [38;5;2mDebug      [39m: Now if I wanted to print a really long text I can use %k: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin congue, libero vitae condimentum egestas, tortor metus condimentum augue, in pretium dolor purus quis lectus. Aenean nunc sapien, eleifend quis convallis ut, venenatis quis mauris. Morbi tempor, ex a lobortis luctus, sem nunc laoreet dolor, pellentesque gravida mauris risus nec est. Aliquam ante sapien, vehicula vel elementum at, feugiat quis libero. Nulla in lorem eu erat vulputate efficitur. Etiam dapibus purus sed sagittis lobortis. Sed quis porttitor nulla. Nulla in ante ac arcu semper efficitur ut at erat. Fusce porttitor suscipit augue. Donec vel lorem justo. Aenean id dolor quis erat blandit cursus. Aenean varius fringilla eros vitae vestibulum.
+66.000000    [38;5;1mError      [39m: different unsigned sizes: 123, 43212, 123123123, 123123123, 123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 43[39m
+67.000000    [38;5;1mError      [39m: different signed sizes: -123, -13212, -123123123, -123123123, -123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 49[39m
+68.000000    [38;5;1mError      [39m: different octal sizes: 123, 123, 123123, 123123123, 123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 55[39m
+69.000000    [38;5;1mError      [39m: different hex sizes: f3, 1321, 12341235, 12341234, 1234567812345678
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 61[39m
+70.000000    [38;5;1mError      [39m: Pointer 0x12341234
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 62[39m
+71.000000    [38;5;2mDebug      [39m: Now if I wanted to print a really long text I can use %k: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin congue, libero vitae condimentum egestas, tortor metus condimentum augue, in pretium dolor purus quis lectus. Aenean nunc sapien, eleifend quis convallis ut, venenatis quis mauris. Morbi tempor, ex a lobortis luctus, sem nunc laoreet dolor, pellentesque gravida mauris risus nec est. Aliquam ante sapien, vehicula vel elementum at, feugiat quis libero. Nulla in lorem eu erat vulputate efficitur. Etiam dapibus purus sed sagittis lobortis. Sed quis porttitor nulla. Nulla in ante ac arcu semper efficitur ut at erat. Fusce porttitor suscipit augue. Donec vel lorem justo. Aenean id dolor quis erat blandit cursus. Aenean varius fringilla eros vitae vestibulum.
 Morbi tristique tristique nulla, at posuere ex sagittis at. Aliquam est quam, porta nec erat ac, convallis tempus augue. Nam eu quam vulputate, luctus sapien vel, tristique arcu. Suspendisse et ultrices odio. Pellentesque consectetur lacus sapien, ut ornare odio sagittis vel. Cras molestie eros odio, vitae ullamcorper ante vestibulum non. Vestibulum facilisis diam vel condimentum gravida. Donec in odio sit amet metus aliquet pharetra ac in ante. Phasellus sit amet dui vehicula, tristique neque et, ullamcorper est. Integer ullamcorper risus in mattis laoreet. Nullam dignissim vel ex vel molestie. Vestibulum id eleifend metus. Curabitur malesuada condimentum augue ut molestie. Vivamus pellentesque purus sed velit placerat ultricies. In ut erat diam. Suspendisse potenti.
-[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 65[39m
-42.000000    [38;5;2mDebug      [39m: Iteration number: 6
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 90[39m
+72.000000    [38;5;2mDebug      [39m: Iteration number: 6
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 31[39m
-43.000000    [38;5;2mDebug      [39m: Is this nice or what?!
+73.000000    [38;5;2mDebug      [39m: Is this nice or what?!
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 32[39m
-44.000000    [38;5;3mInfo       [39m: I am 28 years old...
+74.000000    [38;5;3mInfo       [39m: I am 28 years old...
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 33[39m
-45.000000    [38;2;255;165;0mWarning    [39m: Third string! With multiple args and more numbers: -1124
+75.000000    [38;2;255;165;0mWarning    [39m: Third string! With multiple args and more numbers: -1124
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 34[39m
-46.000000    [38;5;1mError      [39m: Oh boy, error 234556 just happened
+76.000000    [38;5;1mError      [39m: Oh boy, error 234556 just happened
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 35[39m
-47.000000    [38;5;1mError      [39m: This is my char array: 123
+77.000000    [38;5;1mError      [39m: This is my char array: 123
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 37[39m
-48.000000    [38;5;2mDebug      [39m: Now if I wanted to print a really long text I can use %k: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin congue, libero vitae condimentum egestas, tortor metus condimentum augue, in pretium dolor purus quis lectus. Aenean nunc sapien, eleifend quis convallis ut, venenatis quis mauris. Morbi tempor, ex a lobortis luctus, sem nunc laoreet dolor, pellentesque gravida mauris risus nec est. Aliquam ante sapien, vehicula vel elementum at, feugiat quis libero. Nulla in lorem eu erat vulputate efficitur. Etiam dapibus purus sed sagittis lobortis. Sed quis porttitor nulla. Nulla in ante ac arcu semper efficitur ut at erat. Fusce porttitor suscipit augue. Donec vel lorem justo. Aenean id dolor quis erat blandit cursus. Aenean varius fringilla eros vitae vestibulum.
+78.000000    [38;5;1mError      [39m: different unsigned sizes: 123, 43212, 123123123, 123123123, 123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 43[39m
+79.000000    [38;5;1mError      [39m: different signed sizes: -123, -13212, -123123123, -123123123, -123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 49[39m
+80.000000    [38;5;1mError      [39m: different octal sizes: 123, 123, 123123, 123123123, 123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 55[39m
+81.000000    [38;5;1mError      [39m: different hex sizes: f3, 1321, 12341235, 12341234, 1234567812345678
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 61[39m
+82.000000    [38;5;1mError      [39m: Pointer 0x12341234
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 62[39m
+83.000000    [38;5;2mDebug      [39m: Now if I wanted to print a really long text I can use %k: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin congue, libero vitae condimentum egestas, tortor metus condimentum augue, in pretium dolor purus quis lectus. Aenean nunc sapien, eleifend quis convallis ut, venenatis quis mauris. Morbi tempor, ex a lobortis luctus, sem nunc laoreet dolor, pellentesque gravida mauris risus nec est. Aliquam ante sapien, vehicula vel elementum at, feugiat quis libero. Nulla in lorem eu erat vulputate efficitur. Etiam dapibus purus sed sagittis lobortis. Sed quis porttitor nulla. Nulla in ante ac arcu semper efficitur ut at erat. Fusce porttitor suscipit augue. Donec vel lorem justo. Aenean id dolor quis erat blandit cursus. Aenean varius fringilla eros vitae vestibulum.
 Morbi tristique tristique nulla, at posuere ex sagittis at. Aliquam est quam, porta nec erat ac, convallis tempus augue. Nam eu quam vulputate, luctus sapien vel, tristique arcu. Suspendisse et ultrices odio. Pellentesque consectetur lacus sapien, ut ornare odio sagittis vel. Cras molestie eros odio, vitae ullamcorper ante vestibulum non. Vestibulum facilisis diam vel condimentum gravida. Donec in odio sit amet metus aliquet pharetra ac in ante. Phasellus sit amet dui vehicula, tristique neque et, ullamcorper est. Integer ullamcorper risus in mattis laoreet. Nullam dignissim vel ex vel molestie. Vestibulum id eleifend metus. Curabitur malesuada condimentum augue ut molestie. Vivamus pellentesque purus sed velit placerat ultricies. In ut erat diam. Suspendisse potenti.
-[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 65[39m
-49.000000    [38;5;2mDebug      [39m: Iteration number: 7
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 90[39m
+84.000000    [38;5;2mDebug      [39m: Iteration number: 7
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 31[39m
-50.000000    [38;5;2mDebug      [39m: Is this nice or what?!
+85.000000    [38;5;2mDebug      [39m: Is this nice or what?!
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 32[39m
-51.000000    [38;5;3mInfo       [39m: I am 28 years old...
+86.000000    [38;5;3mInfo       [39m: I am 28 years old...
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 33[39m
-52.000000    [38;2;255;165;0mWarning    [39m: Third string! With multiple args and more numbers: -1124
+87.000000    [38;2;255;165;0mWarning    [39m: Third string! With multiple args and more numbers: -1124
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 34[39m
-53.000000    [38;5;1mError      [39m: Oh boy, error 234556 just happened
+88.000000    [38;5;1mError      [39m: Oh boy, error 234556 just happened
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 35[39m
-54.000000    [38;5;1mError      [39m: This is my char array: 123
+89.000000    [38;5;1mError      [39m: This is my char array: 123
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 37[39m
-55.000000    [38;5;2mDebug      [39m: Now if I wanted to print a really long text I can use %k: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin congue, libero vitae condimentum egestas, tortor metus condimentum augue, in pretium dolor purus quis lectus. Aenean nunc sapien, eleifend quis convallis ut, venenatis quis mauris. Morbi tempor, ex a lobortis luctus, sem nunc laoreet dolor, pellentesque gravida mauris risus nec est. Aliquam ante sapien, vehicula vel elementum at, feugiat quis libero. Nulla in lorem eu erat vulputate efficitur. Etiam dapibus purus sed sagittis lobortis. Sed quis porttitor nulla. Nulla in ante ac arcu semper efficitur ut at erat. Fusce porttitor suscipit augue. Donec vel lorem justo. Aenean id dolor quis erat blandit cursus. Aenean varius fringilla eros vitae vestibulum.
+90.000000    [38;5;1mError      [39m: different unsigned sizes: 123, 43212, 123123123, 123123123, 123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 43[39m
+91.000000    [38;5;1mError      [39m: different signed sizes: -123, -13212, -123123123, -123123123, -123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 49[39m
+92.000000    [38;5;1mError      [39m: different octal sizes: 123, 123, 123123, 123123123, 123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 55[39m
+93.000000    [38;5;1mError      [39m: different hex sizes: f3, 1321, 12341235, 12341234, 1234567812345678
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 61[39m
+94.000000    [38;5;1mError      [39m: Pointer 0x12341234
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 62[39m
+95.000000    [38;5;2mDebug      [39m: Now if I wanted to print a really long text I can use %k: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin congue, libero vitae condimentum egestas, tortor metus condimentum augue, in pretium dolor purus quis lectus. Aenean nunc sapien, eleifend quis convallis ut, venenatis quis mauris. Morbi tempor, ex a lobortis luctus, sem nunc laoreet dolor, pellentesque gravida mauris risus nec est. Aliquam ante sapien, vehicula vel elementum at, feugiat quis libero. Nulla in lorem eu erat vulputate efficitur. Etiam dapibus purus sed sagittis lobortis. Sed quis porttitor nulla. Nulla in ante ac arcu semper efficitur ut at erat. Fusce porttitor suscipit augue. Donec vel lorem justo. Aenean id dolor quis erat blandit cursus. Aenean varius fringilla eros vitae vestibulum.
 Morbi tristique tristique nulla, at posuere ex sagittis at. Aliquam est quam, porta nec erat ac, convallis tempus augue. Nam eu quam vulputate, luctus sapien vel, tristique arcu. Suspendisse et ultrices odio. Pellentesque consectetur lacus sapien, ut ornare odio sagittis vel. Cras molestie eros odio, vitae ullamcorper ante vestibulum non. Vestibulum facilisis diam vel condimentum gravida. Donec in odio sit amet metus aliquet pharetra ac in ante. Phasellus sit amet dui vehicula, tristique neque et, ullamcorper est. Integer ullamcorper risus in mattis laoreet. Nullam dignissim vel ex vel molestie. Vestibulum id eleifend metus. Curabitur malesuada condimentum augue ut molestie. Vivamus pellentesque purus sed velit placerat ultricies. In ut erat diam. Suspendisse potenti.
-[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 65[39m
-56.000000    [38;5;2mDebug      [39m: Iteration number: 8
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 90[39m
+96.000000    [38;5;2mDebug      [39m: Iteration number: 8
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 31[39m
-57.000000    [38;5;2mDebug      [39m: Is this nice or what?!
+97.000000    [38;5;2mDebug      [39m: Is this nice or what?!
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 32[39m
-58.000000    [38;5;3mInfo       [39m: I am 28 years old...
+98.000000    [38;5;3mInfo       [39m: I am 28 years old...
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 33[39m
-59.000000    [38;2;255;165;0mWarning    [39m: Third string! With multiple args and more numbers: -1124
+99.000000    [38;2;255;165;0mWarning    [39m: Third string! With multiple args and more numbers: -1124
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 34[39m
-60.000000    [38;5;1mError      [39m: Oh boy, error 234556 just happened
+100.000000   [38;5;1mError      [39m: Oh boy, error 234556 just happened
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 35[39m
-61.000000    [38;5;1mError      [39m: This is my char array: 123
+101.000000   [38;5;1mError      [39m: This is my char array: 123
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 37[39m
-62.000000    [38;5;2mDebug      [39m: Now if I wanted to print a really long text I can use %k: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin congue, libero vitae condimentum egestas, tortor metus condimentum augue, in pretium dolor purus quis lectus. Aenean nunc sapien, eleifend quis convallis ut, venenatis quis mauris. Morbi tempor, ex a lobortis luctus, sem nunc laoreet dolor, pellentesque gravida mauris risus nec est. Aliquam ante sapien, vehicula vel elementum at, feugiat quis libero. Nulla in lorem eu erat vulputate efficitur. Etiam dapibus purus sed sagittis lobortis. Sed quis porttitor nulla. Nulla in ante ac arcu semper efficitur ut at erat. Fusce porttitor suscipit augue. Donec vel lorem justo. Aenean id dolor quis erat blandit cursus. Aenean varius fringilla eros vitae vestibulum.
+102.000000   [38;5;1mError      [39m: different unsigned sizes: 123, 43212, 123123123, 123123123, 123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 43[39m
+103.000000   [38;5;1mError      [39m: different signed sizes: -123, -13212, -123123123, -123123123, -123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 49[39m
+104.000000   [38;5;1mError      [39m: different octal sizes: 123, 123, 123123, 123123123, 123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 55[39m
+105.000000   [38;5;1mError      [39m: different hex sizes: f3, 1321, 12341235, 12341234, 1234567812345678
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 61[39m
+106.000000   [38;5;1mError      [39m: Pointer 0x12341234
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 62[39m
+107.000000   [38;5;2mDebug      [39m: Now if I wanted to print a really long text I can use %k: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin congue, libero vitae condimentum egestas, tortor metus condimentum augue, in pretium dolor purus quis lectus. Aenean nunc sapien, eleifend quis convallis ut, venenatis quis mauris. Morbi tempor, ex a lobortis luctus, sem nunc laoreet dolor, pellentesque gravida mauris risus nec est. Aliquam ante sapien, vehicula vel elementum at, feugiat quis libero. Nulla in lorem eu erat vulputate efficitur. Etiam dapibus purus sed sagittis lobortis. Sed quis porttitor nulla. Nulla in ante ac arcu semper efficitur ut at erat. Fusce porttitor suscipit augue. Donec vel lorem justo. Aenean id dolor quis erat blandit cursus. Aenean varius fringilla eros vitae vestibulum.
 Morbi tristique tristique nulla, at posuere ex sagittis at. Aliquam est quam, porta nec erat ac, convallis tempus augue. Nam eu quam vulputate, luctus sapien vel, tristique arcu. Suspendisse et ultrices odio. Pellentesque consectetur lacus sapien, ut ornare odio sagittis vel. Cras molestie eros odio, vitae ullamcorper ante vestibulum non. Vestibulum facilisis diam vel condimentum gravida. Donec in odio sit amet metus aliquet pharetra ac in ante. Phasellus sit amet dui vehicula, tristique neque et, ullamcorper est. Integer ullamcorper risus in mattis laoreet. Nullam dignissim vel ex vel molestie. Vestibulum id eleifend metus. Curabitur malesuada condimentum augue ut molestie. Vivamus pellentesque purus sed velit placerat ultricies. In ut erat diam. Suspendisse potenti.
-[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 65[39m
-63.000000    [38;5;2mDebug      [39m: Iteration number: 9
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 90[39m
+108.000000   [38;5;2mDebug      [39m: Iteration number: 9
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 31[39m
-64.000000    [38;5;2mDebug      [39m: Is this nice or what?!
+109.000000   [38;5;2mDebug      [39m: Is this nice or what?!
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 32[39m
-65.000000    [38;5;3mInfo       [39m: I am 28 years old...
+110.000000   [38;5;3mInfo       [39m: I am 28 years old...
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 33[39m
-66.000000    [38;2;255;165;0mWarning    [39m: Third string! With multiple args and more numbers: -1124
+111.000000   [38;2;255;165;0mWarning    [39m: Third string! With multiple args and more numbers: -1124
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 34[39m
-67.000000    [38;5;1mError      [39m: Oh boy, error 234556 just happened
+112.000000   [38;5;1mError      [39m: Oh boy, error 234556 just happened
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 35[39m
-68.000000    [38;5;1mError      [39m: This is my char array: 123
+113.000000   [38;5;1mError      [39m: This is my char array: 123
 [38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 37[39m
-69.000000    [38;5;2mDebug      [39m: Now if I wanted to print a really long text I can use %k: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin congue, libero vitae condimentum egestas, tortor metus condimentum augue, in pretium dolor purus quis lectus. Aenean nunc sapien, eleifend quis convallis ut, venenatis quis mauris. Morbi tempor, ex a lobortis luctus, sem nunc laoreet dolor, pellentesque gravida mauris risus nec est. Aliquam ante sapien, vehicula vel elementum at, feugiat quis libero. Nulla in lorem eu erat vulputate efficitur. Etiam dapibus purus sed sagittis lobortis. Sed quis porttitor nulla. Nulla in ante ac arcu semper efficitur ut at erat. Fusce porttitor suscipit augue. Donec vel lorem justo. Aenean id dolor quis erat blandit cursus. Aenean varius fringilla eros vitae vestibulum.
+114.000000   [38;5;1mError      [39m: different unsigned sizes: 123, 43212, 123123123, 123123123, 123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 43[39m
+115.000000   [38;5;1mError      [39m: different signed sizes: -123, -13212, -123123123, -123123123, -123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 49[39m
+116.000000   [38;5;1mError      [39m: different octal sizes: 123, 123, 123123, 123123123, 123123123
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 55[39m
+117.000000   [38;5;1mError      [39m: different hex sizes: f3, 1321, 12341235, 12341234, 1234567812345678
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 61[39m
+118.000000   [38;5;1mError      [39m: Pointer 0x12341234
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 62[39m
+119.000000   [38;5;2mDebug      [39m: Now if I wanted to print a really long text I can use %k: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin congue, libero vitae condimentum egestas, tortor metus condimentum augue, in pretium dolor purus quis lectus. Aenean nunc sapien, eleifend quis convallis ut, venenatis quis mauris. Morbi tempor, ex a lobortis luctus, sem nunc laoreet dolor, pellentesque gravida mauris risus nec est. Aliquam ante sapien, vehicula vel elementum at, feugiat quis libero. Nulla in lorem eu erat vulputate efficitur. Etiam dapibus purus sed sagittis lobortis. Sed quis porttitor nulla. Nulla in ante ac arcu semper efficitur ut at erat. Fusce porttitor suscipit augue. Donec vel lorem justo. Aenean id dolor quis erat blandit cursus. Aenean varius fringilla eros vitae vestibulum.
 Morbi tristique tristique nulla, at posuere ex sagittis at. Aliquam est quam, porta nec erat ac, convallis tempus augue. Nam eu quam vulputate, luctus sapien vel, tristique arcu. Suspendisse et ultrices odio. Pellentesque consectetur lacus sapien, ut ornare odio sagittis vel. Cras molestie eros odio, vitae ullamcorper ante vestibulum non. Vestibulum facilisis diam vel condimentum gravida. Donec in odio sit amet metus aliquet pharetra ac in ante. Phasellus sit amet dui vehicula, tristique neque et, ullamcorper est. Integer ullamcorper risus in mattis laoreet. Nullam dignissim vel ex vel molestie. Vestibulum id eleifend metus. Curabitur malesuada condimentum augue ut molestie. Vivamus pellentesque purus sed velit placerat ultricies. In ut erat diam. Suspendisse potenti.
-[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 65[39m
+[38;5;8m└── File: postform/app/src/host_main.cpp, Line number: 90[39m


### PR DESCRIPTION
Add the sized variants of %d and %u, %x and %o

Change-Id: Ie5cd1c7270a6d3886f88d5a717820f41f34a6d81