### PR TITLE
Build arguments and pass them to the logger

### DIFF
--- a/app/src/log.cpp
+++ b/app/src/log.cpp
@@ -1,0 +1,143 @@
+
+#include "postform/file_logger.h"
+#include <stdio.h>
+
+void log(Postform::FileLogger& logger) {
+  uint32_t iteration = 0;
+  for (uint32_t i = 0; i < 10; i++) {
+    // All the logs here together act as the worst case for the decoder. Without proper framing
+    // they would be confused from the host. If they all show that means that the COBS framing works
+    LOG_DEBUG(&logger, "Iteration number: %u", iteration);
+    LOG_DEBUG(&logger, "Is this %s or what?!", "nice");
+    LOG_INFO(&logger, "I am %d years old...", 28);
+    LOG_WARNING(&logger, "Third string! With multiple %s and more numbers: %d", "args", -1124);
+    LOG_ERROR(&logger, "Oh boy, error %d just happened", 234556);
+    char char_array[] = "123";
+    LOG_ERROR(&logger, "This is my char array: %s", char_array);
+    LOG_ERROR(&logger, "different unsigned sizes: %hhu, %hu, %u, %lu, %llu",
+        static_cast<unsigned char>(123),
+        static_cast<unsigned short>(43212),
+        static_cast<unsigned int>(123123123),
+        static_cast<unsigned long>(123123123),
+        static_cast<unsigned long long>(123123123));
+    LOG_ERROR(&logger, "different signed sizes: %hhd, %hd, %d, %ld, %lld",
+        static_cast<signed char>(-123),
+        static_cast<short>(-13212),
+        static_cast<int>(-123123123),
+        static_cast<long>(-123123123),
+        static_cast<long long>(-123123123));
+    LOG_ERROR(&logger, "different octal sizes: %hho, %ho, %o, %lo, %llo",
+        static_cast<unsigned char>(0123),
+        static_cast<unsigned short>(0123),
+        static_cast<unsigned int>(0123123),
+        static_cast<unsigned long>(0123123123),
+        static_cast<unsigned long long>(0123123123));
+    LOG_ERROR(&logger, "different hex sizes: %hhx, %hx, %x, %lx, %llx",
+        static_cast<unsigned char>(0xf3),
+        static_cast<unsigned short>(0x1321),
+        static_cast<unsigned int>(0x12341235),
+        static_cast<unsigned long>(0x12341234),
+        static_cast<unsigned long long>(0x1234567812345678));
+    LOG_ERROR(&logger, "Pointer %p", reinterpret_cast<void*>(0x12341234));
+
+    constexpr auto interned_string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+                             "Proin congue, libero vitae condimentum egestas, tortor metus "
+                             "condimentum augue, in pretium dolor purus quis lectus. Aenean "
+                             "nunc sapien, eleifend quis convallis ut, venenatis quis mauris. "
+                             "Morbi tempor, ex a lobortis luctus, sem nunc laoreet dolor, "
+                             "pellentesque gravida mauris risus nec est. Aliquam ante sapien, "
+                             "vehicula vel elementum at, feugiat quis libero. Nulla in lorem eu "
+                             "erat vulputate efficitur. Etiam dapibus purus sed sagittis lobortis. "
+                             "Sed quis porttitor nulla. Nulla in ante ac arcu semper efficitur ut "
+                             "at erat. Fusce porttitor suscipit augue. Donec vel lorem justo. "
+                             "Aenean id dolor quis erat blandit cursus. Aenean varius fringilla "
+                             "eros vitae vestibulum.\n"
+                             "Morbi tristique tristique nulla, at posuere ex sagittis at. Aliquam "
+                             "est quam, porta nec erat ac, convallis tempus augue. Nam eu quam "
+                             "vulputate, luctus sapien vel, tristique arcu. Suspendisse et ultrices "
+                             "odio. Pellentesque consectetur lacus sapien, ut ornare odio sagittis "
+                             "vel. Cras molestie eros odio, vitae ullamcorper ante vestibulum non. "
+                             "Vestibulum facilisis diam vel condimentum gravida. Donec in odio sit "
+                             "amet metus aliquet pharetra ac in ante. Phasellus sit amet dui vehicula, "
+                             "tristique neque et, ullamcorper est. Integer ullamcorper risus in mattis "
+                             "laoreet. Nullam dignissim vel ex vel molestie. Vestibulum id eleifend "
+                             "metus. Curabitur malesuada condimentum augue ut molestie. Vivamus "
+                             "pellentesque purus sed velit placerat ultricies. In ut erat diam. "
+                             "Suspendisse potenti."_intern;
+
+    LOG_DEBUG(&logger, "Now if I wanted to print a really long text I can use %%k: %k",
+              interned_string);
+
+    iteration++;
+  }
+}
+
+void log_printf() {
+  uint32_t iteration = 0;
+  for (uint32_t i = 0; i < 10; i++) {
+    // All the logs here together act as the worst case for the decoder. Without proper framing
+    // they would be confused from the host. If they all show that means that the COBS framing works
+    printf("Iteration number: %u", iteration);
+    printf("Is this %s or what?!", "nice");
+    printf("I am %d years old...", 28);
+    printf("Third string! With multiple %s and more numbers: %d", "args", -1124);
+    printf("Oh boy, error %d just happened", 234556);
+    char char_array[] = "123";
+    printf("This is my char array: %s", char_array);
+    printf("different unsigned sizes: %hhu, %hu, %u, %lu, %llu",
+        static_cast<unsigned char>(123),
+        static_cast<unsigned short>(43212),
+        static_cast<unsigned int>(123123123),
+        static_cast<unsigned long>(123123123),
+        static_cast<unsigned long long>(123123123));
+    printf("different signed sizes: %hhd, %hd, %d, %ld, %lld",
+        static_cast<signed char>(-123),
+        static_cast<short>(-13212),
+        static_cast<int>(-123123123),
+        static_cast<long>(-123123123),
+        static_cast<long long>(-123123123));
+    printf("different octal sizes: %hho, %ho, %o, %lo, %llo",
+        static_cast<unsigned char>(0123),
+        static_cast<unsigned short>(0123),
+        static_cast<unsigned int>(0123123),
+        static_cast<unsigned long>(0123123123),
+        static_cast<unsigned long long>(0123123123));
+    printf("different hex sizes: %hhx, %hx, %x, %lx, %llx",
+        static_cast<unsigned char>(0xf3),
+        static_cast<unsigned short>(0x1321),
+        static_cast<unsigned int>(0x12341235),
+        static_cast<unsigned long>(0x12341234),
+        static_cast<unsigned long long>(0x1234567812345678));
+    printf("Pointer %p", reinterpret_cast<void*>(0x12341234));
+
+    const char* interned_string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+                             "Proin congue, libero vitae condimentum egestas, tortor metus "
+                             "condimentum augue, in pretium dolor purus quis lectus. Aenean "
+                             "nunc sapien, eleifend quis convallis ut, venenatis quis mauris. "
+                             "Morbi tempor, ex a lobortis luctus, sem nunc laoreet dolor, "
+                             "pellentesque gravida mauris risus nec est. Aliquam ante sapien, "
+                             "vehicula vel elementum at, feugiat quis libero. Nulla in lorem eu "
+                             "erat vulputate efficitur. Etiam dapibus purus sed sagittis lobortis. "
+                             "Sed quis porttitor nulla. Nulla in ante ac arcu semper efficitur ut "
+                             "at erat. Fusce porttitor suscipit augue. Donec vel lorem justo. "
+                             "Aenean id dolor quis erat blandit cursus. Aenean varius fringilla "
+                             "eros vitae vestibulum.\n"
+                             "Morbi tristique tristique nulla, at posuere ex sagittis at. Aliquam "
+                             "est quam, porta nec erat ac, convallis tempus augue. Nam eu quam "
+                             "vulputate, luctus sapien vel, tristique arcu. Suspendisse et ultrices "
+                             "odio. Pellentesque consectetur lacus sapien, ut ornare odio sagittis "
+                             "vel. Cras molestie eros odio, vitae ullamcorper ante vestibulum non. "
+                             "Vestibulum facilisis diam vel condimentum gravida. Donec in odio sit "
+                             "amet metus aliquet pharetra ac in ante. Phasellus sit amet dui vehicula, "
+                             "tristique neque et, ullamcorper est. Integer ullamcorper risus in mattis "
+                             "laoreet. Nullam dignissim vel ex vel molestie. Vestibulum id eleifend "
+                             "metus. Curabitur malesuada condimentum augue ut molestie. Vivamus "
+                             "pellentesque purus sed velit placerat ultricies. In ut erat diam. "
+                             "Suspendisse potenti.";
+
+    printf("Now if I wanted to print a really long text I can use %%k: %s",
+              interned_string);
+
+    iteration++;
+  }
+}

--- a/libpostform/inc/postform/args.h
+++ b/libpostform/inc/postform/args.h
@@ -1,0 +1,80 @@
+#ifndef POSTFORM_ARGS_H_
+#define POSTFORM_ARGS_H_
+
+#include <array>
+#include <postform/types.h>
+#include <type_traits>
+
+namespace Postform {
+
+class Argument {
+ public:
+  const union {
+    unsigned long long unsigned_long_long;
+    signed long long signed_long_long;
+    const char* str_ptr;
+    const void* void_ptr;
+    InternedString interned_string;
+  };
+
+  const std::size_t size = 0;
+
+  const enum class Type {
+    UNSIGNED_INTEGER,
+    SIGNED_INTEGER,
+    STRING_POINTER,
+    VOID_PTR,
+    INTERNED_STRING
+  } type;
+};
+
+template<class T, std::enable_if_t<std::is_integral_v<T> && std::is_signed_v<T>, bool> = true>
+constexpr Argument make_arg(T value) {
+  return Argument {
+    .signed_long_long = value,
+    .size = sizeof(T),
+    .type = Argument::Type::SIGNED_INTEGER
+  };
+}
+
+template<class T, std::enable_if_t<std::is_integral_v<T> && std::is_unsigned_v<T>, bool> = true>
+constexpr Argument make_arg(T value) {
+  return Argument {
+    .unsigned_long_long = value,
+    .size = sizeof(T),
+    .type = Argument::Type::UNSIGNED_INTEGER,
+  };
+}
+
+template<class T, std::enable_if_t<std::is_convertible_v<T, const char*>, bool> = true>
+constexpr Argument make_arg(T value) {
+  return Argument {
+    .str_ptr = value,
+    .type = Argument::Type::STRING_POINTER
+  };
+}
+
+template<class T, std::enable_if_t<!std::is_convertible_v<T, const char*> &&
+                                   std::is_convertible_v<T, const void*>, bool> = true>
+constexpr Argument make_arg(T value) {
+  return Argument {
+    .void_ptr = value,
+    .type = Argument::Type::VOID_PTR
+  };
+}
+
+constexpr Argument make_arg(InternedString value) {
+  return Argument {
+    .interned_string = value,
+    .type = Argument::Type::INTERNED_STRING
+  };
+}
+
+template<class... T>
+constexpr std::array<Argument, sizeof...(T)> build_args(T... args) {
+  return { make_arg(args)... };
+}
+
+}  // namespace Postform
+
+#endif  // POSTFORM_ARGS_H_


### PR DESCRIPTION
This is an effort to try and reduce code bloat due to the templates by
isolating the duplicated code into a constexpr enabled series of
functions during build time, while keeping the logger code free of
templates.

It gives a pretty good improvement of saving 1kB in the test app.
It also improves runtime slightly.

Before
4730          1056     104    5890    1702 build/targets/format
After
3854          1056     104    5014    1396 build/targets/format

Closes #52

Change-Id: Id5e5f65b28f56c50abc677afdf068c3b5c73b265