### PR TITLE
Apply proper memory order for atomics

### DIFF
--- a/app/src/host_main.cpp
+++ b/app/src/host_main.cpp
@@ -8,7 +8,7 @@
 namespace Postform {
 uint64_t getGlobalTimestamp() {
   static std::atomic_uint64_t count;
-  return count.fetch_add(1);
+  return count.fetch_add(1, std::memory_order_relaxed);
 }
 }  // namespace Postform
 

--- a/libpostform/inc/postform/logger.h
+++ b/libpostform/inc/postform/logger.h
@@ -70,7 +70,7 @@ class Logger {
    */
   template<typename ... T>
   inline void log(LogLevel level, T ...args) {
-    if (level < m_level.load()) return;
+    if (level < m_level.load(std::memory_order_relaxed)) return;
     const auto arg_array = build_args(args...);
     vlog(arg_array.data(), arg_array.size());
   }
@@ -118,7 +118,7 @@ class Logger {
    * Logs with levels above or equal the selected one are printed.
    * Others are ignored.
    */
-  void setLevel(LogLevel level) { m_level.store(level); }
+  void setLevel(LogLevel level) { m_level.store(level, std::memory_order_relaxed); }
 
  private:
   std::atomic<LogLevel> m_level = LogLevel::DEBUG;

--- a/libpostform/inc/postform/rtt/cobs_writer.h
+++ b/libpostform/inc/postform/rtt/cobs_writer.h
@@ -2,6 +2,7 @@
 #ifndef POSTFORM_RTT_COBS_WRITER_H_
 #define POSTFORM_RTT_COBS_WRITER_H_
 
+#include <atomic>
 #include <cstdint>
 
 #include "postform/rtt/rtt.h"
@@ -34,13 +35,13 @@ class CobsWriter {
   CobsWriter(Manager* rtt, Channel* channel);
 
   inline void blockUntilNotFull() {
-    if (m_channel->flags != Rtt::Flags::BLOCK_IF_FULL) {
+    if (m_channel->flags.load(std::memory_order_relaxed) != Rtt::Flags::BLOCK_IF_FULL) {
       return;
     }
     const uint32_t next_write_ptr = nextWritePtr();
-    if (m_channel->read == next_write_ptr) {
-      m_channel->write.store(m_marker_ptr);
-      while (m_channel->read.load() == next_write_ptr) { }
+    if (m_channel->read.load(std::memory_order_acquire) == next_write_ptr) {
+      m_channel->write.store(m_marker_ptr, std::memory_order_release);
+      while (m_channel->read.load(std::memory_order_relaxed) == next_write_ptr) { }
     }
   }
 

--- a/libpostform/inc/postform/rtt/rtt_manager.h
+++ b/libpostform/inc/postform/rtt/rtt_manager.h
@@ -26,11 +26,11 @@ class Manager {
 
   Manager() = default;
   void releaseWriter() {
-    m_taken.store(false);
+    m_taken.store(false, std::memory_order_release);
   }
 
   bool takeWriter() {
-    return !m_taken.exchange(true);
+    return !m_taken.exchange(true, std::memory_order_acq_rel);
   }
 
   friend class RawWriter;

--- a/libpostform/src/rtt/raw_writer.cpp
+++ b/libpostform/src/rtt/raw_writer.cpp
@@ -57,7 +57,7 @@ void Rtt::RawWriter::write(const uint8_t* data, uint32_t size) {
       // Currently this only implements the blocking TX mode. We may need to add support
       // for other modes in the future.
       // We write the current buffer as is and then wait for more memory to be available
-      m_channel->write = m_write_ptr;
+      m_channel->write.store(m_write_ptr, std::memory_order_release);
       continue;
     }
 
@@ -79,14 +79,14 @@ void Rtt::RawWriter::write(const uint8_t* data, uint32_t size) {
 void Rtt::RawWriter::commit() {
   if (m_state == State::Writable) {
     // Update the write pointer and mark the writer as done
-    m_channel->write = m_write_ptr;
+    m_channel->write.store(m_write_ptr, std::memory_order_release);
     m_state = State::Finished;
     if (m_manager) m_manager->releaseWriter();
   }
 }
 
 uint32_t Rtt::RawWriter::getMaxContiguous() const {
-  uint32_t read = m_channel->read;
+  uint32_t read = m_channel->read.load(std::memory_order_acquire);
   uint32_t channel_size = m_channel->size;
 
   if (read == 0) {


### PR DESCRIPTION
Instead of using the default sequentially consistent order, let's apply
proper order as defined by the C++11 memory model.

Change-Id: I0e5c21cb85f037d766782b45e0fe75a095e5ec63