### PR TITLE
Fix format validation for pointer types

### DIFF
--- a/libpostform/inc/postform/format_validator.h
+++ b/libpostform/inc/postform/format_validator.h
@@ -70,7 +70,7 @@ template <class T>
                                          integer_size_handlers.size()},
                         "x", []() { return std::is_integral_v<T>; }},
       FormatSpecHandler{SizeSpecHandlers{}, "p",
-                        []() { return std::is_convertible_v<T, void*>; }},
+                        []() { return std::is_pointer_v<T>; }},
       FormatSpecHandler{
           SizeSpecHandlers{}, "k",
           []() { return std::is_same_v<T, Postform::InternedString>; }},

--- a/libpostform/src/format_validator.cpp
+++ b/libpostform/src/format_validator.cpp
@@ -5,12 +5,12 @@
 static_assert(POSTFORM_VALIDATE_FORMAT("%u %d", 2u, 1));
 static_assert(POSTFORM_VALIDATE_FORMAT("%s", ""));
 static_assert(POSTFORM_VALIDATE_FORMAT("%d", 2));
-static_assert(!POSTFORM_VALIDATE_FORMAT("%d", (const char*)123ull));
+static_assert(!POSTFORM_VALIDATE_FORMAT("%d", (const char *)123ull));
 static_assert(!POSTFORM_VALIDATE_FORMAT("%s", 123ull));
-static_assert(POSTFORM_VALIDATE_FORMAT("%s %llu %llu, %s", (const char*)123ull,
+static_assert(POSTFORM_VALIDATE_FORMAT("%s %llu %llu, %s", (const char *)123ull,
                                        1ull, 1ull, ""));
 static_assert(POSTFORM_VALIDATE_FORMAT("%s %s %lld, %llu", "",
-                                       (const char*)123ull, 2ll, 12ull));
+                                       (const char *)123ull, 2ll, 12ull));
 static_assert(POSTFORM_VALIDATE_FORMAT("fsdgfds%%"));
 static_assert(!POSTFORM_VALIDATE_FORMAT("fsdgfds%s"));
 static_assert(!POSTFORM_VALIDATE_FORMAT("fsdgfds%a"));
@@ -25,6 +25,12 @@ POSTFORM_ASSERT_FORMAT("%d", 1);
 POSTFORM_ASSERT_FORMAT("%s %d %u, %s", "", 1, 1u, "");
 POSTFORM_ASSERT_FORMAT("%s %s %u, %d", "", "", 1u, 1);
 POSTFORM_ASSERT_FORMAT("fsdgfds%%%%");
+// Test pointers to types with multiple different qualifiers
+POSTFORM_ASSERT_FORMAT("%p", reinterpret_cast<const void *>(0));
+POSTFORM_ASSERT_FORMAT("%p", reinterpret_cast<const volatile void *>(0));
+POSTFORM_ASSERT_FORMAT("%p", reinterpret_cast<uint32_t *>(0));
+// An array type should automatically decay to pointer type
+POSTFORM_ASSERT_FORMAT("%p", *reinterpret_cast<int (*)[1]>(0));
 
 // Compile-time tests for the POSTFORM_EXPAND_COMMA macro
 static_assert(true POSTFORM_EXPAND_COMMA(1) "Comma wasn't expanded!");


### PR DESCRIPTION
We can use the is_pointer_v in type traits to detect pointer types. In
addition, if something can decay to a pointer (like an array), then a
decay<T> is automatically applied so that we can also use array
identifiers without manually coercing the type to a pointer.

Closes #64

Change-Id: Id448e0c483a8ef201d08fd18b2ffed3c013adfab