### PR TITLE
Add serial logger implementation and tests

### DIFF
--- a/libpostform/build.mk
+++ b/libpostform/build.mk
@@ -73,12 +73,14 @@ include $(BUILD_STATIC_LIB)
 include $(CLEAR_VARS)
 LOCAL_NAME := postform_tests
 LOCAL_CFLAGS := \
+    -I$(LOCAL_DIR)/test \
     $(POSTFORM_CFLAGS)
 LOCAL_CXXFLAGS := \
     $(LOCAL_CFLAGS) \
     $(POSTFORM_CXXFLAGS)
 LOCAL_SRC := \
     $(POSTFORM_SRC) \
-    $(LOCAL_DIR)/test/logger_test.cpp
+    $(LOCAL_DIR)/test/timestamp_mock.cpp \
+    $(LOCAL_DIR)/test/logger_test.cpp \
+    $(LOCAL_DIR)/test/serial_logger_test.cpp
 include $(BUILD_HOST_TEST)
-

--- a/libpostform/inc/postform/serial_logger.h
+++ b/libpostform/inc/postform/serial_logger.h
@@ -1,0 +1,210 @@
+
+#ifndef POSTFORM_SERIAL_LOGGER_H_
+#define POSTFORM_SERIAL_LOGGER_H_
+
+#include <atomic>
+
+#include "postform/logger.h"
+
+namespace Postform {
+
+template <class T>
+class SerialLogger;
+
+template <class T>
+class SerialWriter {
+ public:
+  /**
+   * @brief Creates an invalid writer.
+   *
+   * This writer will not be allowed to write to the transport, even if write
+   * and commit are called on it.
+   */
+  SerialWriter() = default;
+
+  /**
+   * @brief Disallow copy, as there should be only a single valid instance of
+   * this object.
+   */
+  SerialWriter(const SerialWriter&) = delete;
+  SerialWriter& operator=(const SerialWriter&) = delete;
+
+  /**
+   * @brief Creates an object moving from another and invalidating the
+   * moved-from object.
+   * @param other The object to move from.
+   */
+  SerialWriter(SerialWriter&& other);
+
+  /**
+   * @brief Moves a writer into another, leaving the moved-from writer invalid
+   * and releasing the current writer if it was valid. moved-from object.
+   * @param other The object to move from.
+   * @return a reference to this instance.
+   */
+  SerialWriter& operator=(SerialWriter&& other);
+
+  /**
+   * @brief The destructor will commit changes if the instance is valid,
+   *        releasing the writer back to the logger.
+   */
+  ~SerialWriter();
+
+  /**
+   * @brief Writes data to the transport. It frames the data using reverse COBS.
+   * @param data Pointer to the data to be written to the transport.
+   * @param size size of the data to be written to the transport.
+   */
+  void write(const uint8_t* data, uint32_t size);
+
+  /**
+   * @brief Commits the changes to the transport. This is how we know when the
+   * message is done.
+   */
+  void commit();
+
+  /**
+   * @brief Implicit bool conversion
+   */
+  operator bool() const;
+
+ private:
+  /**
+   * @brief Possible states of the writer.
+   */
+  enum class State {
+    //! The writer is valid and can write to a transport.
+    Writable,
+    //! The writer is done with the message and can no longer write to the
+    //! transport.
+    Finished
+  };
+
+  SerialLogger<T>* m_logger = nullptr;
+  T* m_transport = nullptr;
+  State m_state = State::Finished;
+
+  /**
+   * @brief Actual constructor for the SerialWriter. Only created from the
+   *        SerialLogger.
+   * @param logger Pointer to the logger instance that created this writer.
+   * @param transport Pointer to the underlying transport for the writer.
+   */
+  SerialWriter(SerialLogger<T>* logger, T* transport);
+
+  //! The logger needs to be able to call this private constructor.
+  //! It should be the only class able to create a valid instance of this
+  //! object.
+  friend class SerialLogger<T>;
+};
+
+template <class T>
+class SerialLogger : public Logger<SerialLogger<T>, SerialWriter<T>> {
+ public:
+  /**
+   * @brief Public constructor for a serial logger. It must be given a transport
+   * to write the serialized data.
+   * @param transport Pointer to the underlying transport. Must implement the
+   * following methods:
+   *
+   * ```c++
+   *   bool write(const uint8_t* data, uint32_t size);
+   *   void commit();
+   * ```
+   */
+  SerialLogger(T* transport) : m_transport(transport) {}
+
+ private:
+  std::atomic_bool m_taken{false};
+  T* m_transport;
+
+  /**
+   * @brief Gets the writer if it is available. If it is already taken (maybe by
+   * some other thread or by our own) we return an invalid instance, since we
+   * can't risk writing to the transport or it could scramble the serial data.
+   */
+  SerialWriter<T> getWriter();
+
+  /**
+   * @brief Releases the writer back to the SerialLogger so that it can be used
+   * again later.
+   */
+  void release();
+
+  friend Logger<SerialLogger<T>, SerialWriter<T>>;
+  friend class SerialWriter<T>;  //! The serial writer must be able to release
+                                 //! itself.
+  friend class SerialLoggerTest;
+};
+
+template <class T>
+SerialWriter<T>::SerialWriter(SerialWriter<T>&& other)
+    : m_logger(other.m_logger),
+      m_transport(other.m_transport),
+      m_state(other.m_state) {
+  other.m_logger = nullptr;
+  other.m_transport = nullptr;
+  other.m_state = State::Finished;
+}
+
+template <class T>
+SerialWriter<T>& SerialWriter<T>::operator=(SerialWriter<T>&& other) {
+  if (&other != this) {
+    m_logger = other.m_logger;
+    m_transport = other.m_transport;
+    m_state = other.m_state;
+    other.m_logger = nullptr;
+    other.m_transport = nullptr;
+    other.m_state = State::Finished;
+  }
+  return *this;
+}
+
+template <class T>
+SerialWriter<T>::~SerialWriter() {
+  commit();
+}
+
+template <class T>
+SerialWriter<T>::operator bool() const {
+  return State::Writable == m_state;
+}
+
+template <class T>
+void SerialWriter<T>::write(const uint8_t* data, uint32_t size) {
+  if (*this) {
+    m_transport->write(data, size);
+  }
+}
+
+template <class T>
+void SerialWriter<T>::commit() {
+  if (*this) {
+    m_state = State::Finished;
+    m_transport->commit();
+    m_transport = nullptr;
+    m_logger->release();
+    m_logger = nullptr;
+  }
+}
+
+template <class T>
+SerialWriter<T>::SerialWriter(SerialLogger<T>* logger, T* transport)
+    : m_logger(logger), m_transport(transport), m_state(State::Writable) {}
+
+template <class T>
+SerialWriter<T> SerialLogger<T>::getWriter() {
+  if (!m_taken.exchange(true, std::memory_order_relaxed)) {
+    return SerialWriter<T>{this, m_transport};
+  }
+  return SerialWriter<T>{};
+}
+
+template <class T>
+void SerialLogger<T>::release() {
+  m_taken.store(false, std::memory_order_relaxed);
+}
+
+}  // namespace Postform
+
+#endif  // POSTFORM_SERIAL_LOGGER_H_

--- a/libpostform/inc/postform/utils.h
+++ b/libpostform/inc/postform/utils.h
@@ -2,6 +2,7 @@
 #ifndef POSTFORM_UTILS_H_
 #define POSTFORM_UTILS_H_
 
+#include <cstddef>
 #include <cstdint>
 
 #define UNINIT __attribute((section(".uninit")))

--- a/libpostform/test/serial_logger_test.cpp
+++ b/libpostform/test/serial_logger_test.cpp
@@ -1,0 +1,151 @@
+
+#include "postform/serial_logger.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "serial_transport_mock.h"
+#include "timestamp_mock.h"
+
+namespace Postform {
+class SerialLoggerMock : public SerialLogger<SerialTransportMock> {
+ public:
+  SerialLoggerMock(SerialTransportMock* transport) : SerialLogger(transport) {}
+};
+
+using testing::_;
+using testing::Mock;
+using testing::Return;
+using testing::StrictMock;
+
+class SerialLoggerTest : public testing::Test {
+ public:
+  void SetUp() { g_timestamp = &timestamp; }
+  void TearDown() { g_timestamp = nullptr; }
+
+  auto getWriter() { return serial_logger.getWriter(); }
+
+  StrictMock<TimestampMock> timestamp;
+  StrictMock<Postform::SerialTransportMock> transport;
+  Postform::SerialLoggerMock serial_logger{&transport};
+};
+
+TEST_F(SerialLoggerTest, CanObtainValidWriter) {
+  auto writer = getWriter();
+  EXPECT_TRUE(writer);
+  EXPECT_CALL(transport, commit());
+}
+
+TEST_F(SerialLoggerTest, CannotObtainTwoValidWriters) {
+  auto writer = getWriter();
+  EXPECT_TRUE(writer);
+  auto second_writer = getWriter();
+  EXPECT_FALSE(second_writer);
+  EXPECT_CALL(transport, commit());
+}
+
+TEST_F(SerialLoggerTest, WriterRunsCommitOnDestruction) {
+  auto writer = getWriter();
+  EXPECT_TRUE(writer);
+  EXPECT_CALL(transport, commit());
+}
+
+TEST_F(SerialLoggerTest, WriterReleasesItself) {
+  {
+    // First get the writer and release it
+    auto writer = getWriter();
+    EXPECT_TRUE(writer);
+    EXPECT_CALL(transport, commit());
+  }
+  {
+    // Now we should be able to get the writer again
+    auto writer = getWriter();
+    EXPECT_TRUE(writer);
+    EXPECT_CALL(transport, commit());
+  }
+}
+
+TEST_F(SerialLoggerTest, DefaultConstructedWriterIsNotValid) {
+  SerialWriter<SerialTransportMock> writer;
+  EXPECT_FALSE(writer);
+}
+
+TEST_F(SerialLoggerTest, CallingCommitOnInvalidWriterDoesNotDoAnything) {
+  // TODO(javier-varez): Test rcobs here when implemented
+  SerialWriter<SerialTransportMock> writer;
+  writer.commit();
+}
+
+TEST_F(SerialLoggerTest, CallingWriteOnInvalidWriterDoesNotDoAnything) {
+  // TODO(javier-varez): Test rcobs here when implemented
+  SerialWriter<SerialTransportMock> writer;
+  uint8_t data[] = {
+      123,
+      213,
+      231,
+  };
+  writer.write(data, 3);
+}
+
+TEST_F(SerialLoggerTest, CallingCommitOnWriterReleasesIt) {
+  auto writer = getWriter();
+  EXPECT_TRUE(writer);
+  EXPECT_CALL(transport, commit());
+  writer.commit();
+  // Make sure commit gets called up to this point
+  Mock::VerifyAndClearExpectations(&transport);
+
+  EXPECT_FALSE(writer);
+  // Now we can acquire it again
+  auto second_writer = getWriter();
+  EXPECT_TRUE(second_writer);
+  EXPECT_CALL(transport, commit());
+}
+
+TEST_F(SerialLoggerTest, CanMoveWriter) {
+  // First get the writer and release it
+  auto writer = getWriter();
+  EXPECT_TRUE(writer);
+
+  // Test the move constructor
+  auto second_writer = std::move(writer);
+  EXPECT_TRUE(second_writer);
+  EXPECT_FALSE(writer);
+
+  // Test the move assignment operator
+  writer = std::move(second_writer);
+  EXPECT_TRUE(writer);
+  EXPECT_FALSE(second_writer);
+
+  // As a result, only a single valid writer should remain, which will call
+  // commit
+  EXPECT_CALL(transport, commit());
+}
+
+TEST_F(SerialLoggerTest, CanWriteToTransport) {
+  // TODO(javier-varez): Test rcobs here when implemented
+  SerialWriter<SerialTransportMock> writer = getWriter();
+
+  uint8_t data[] = {
+      123,
+      213,
+      231,
+  };
+  EXPECT_CALL(transport, write(data, 3));
+  writer.write(data, 3);
+
+  EXPECT_CALL(transport, commit());
+}
+
+TEST_F(SerialLoggerTest, CanUseLogger) {
+  StrictMock<Postform::SerialTransportMock> transport;
+  Postform::SerialLoggerMock serial_logger{&transport};
+
+  EXPECT_CALL(timestamp, getGlobalTimestamp()).WillOnce(Return(0x1234));
+  // There is one write for the timestamp, another for the format string
+  EXPECT_CALL(transport, write(_, _)).Times(2);
+  EXPECT_CALL(transport, commit());
+  LOG_DEBUG(&serial_logger, "Hi there!");
+}
+
+}  // namespace Postform

--- a/libpostform/test/serial_transport_mock.h
+++ b/libpostform/test/serial_transport_mock.h
@@ -1,0 +1,11 @@
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace Postform {
+class SerialTransportMock {
+ public:
+  MOCK_METHOD(bool, write, (const std::uint8_t*, std::uint32_t), ());
+  MOCK_METHOD(void, commit, (), ());
+};
+}  // namespace Postform

--- a/libpostform/test/timestamp_mock.cpp
+++ b/libpostform/test/timestamp_mock.cpp
@@ -1,0 +1,11 @@
+
+#include "timestamp_mock.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+TimestampMock* g_timestamp = nullptr;
+
+namespace Postform {
+uint64_t getGlobalTimestamp() { return g_timestamp->getGlobalTimestamp(); }
+}  // namespace Postform

--- a/libpostform/test/timestamp_mock.h
+++ b/libpostform/test/timestamp_mock.h
@@ -1,0 +1,10 @@
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+class TimestampMock {
+ public:
+  MOCK_METHOD(uint64_t, getGlobalTimestamp, (), ());
+};
+
+extern TimestampMock* g_timestamp;


### PR DESCRIPTION
The serial logger will eventually implement reverse cobs and hook to
either RTT or UART endpoints. This way we can actually have a transport
independent implementation of a serial logger.

Currently this uses no framing protocol, so writes are simply forwarded
to the transport

Change-Id: Icbb2766dff70bb1179b027ddb328a2d8c8cb51d6