### PR TITLE
Postform-serial: Set timeout for serial port

### DIFF
--- a/postform_serial/src/main.rs
+++ b/postform_serial/src/main.rs
@@ -95,6 +95,7 @@ fn main() -> color_eyre::eyre::Result<()> {
         .stop_bits(opts.stop_bits.unwrap_or(StopBits::One))
         .flow_control(FlowControl::None)
         .open()?;
+    port.set_timeout(std::time::Duration::from_millis(100))?;
 
     loop {
         let mut buffer = [0; 1024];


### PR DESCRIPTION
The default timeout may be too large or too small, so lets use a more
reasonable value.

Change-Id: Ie864058774f07ea586f640fcf90b9ff5d34636a8