### PR TITLE
Remove bindings folder

### DIFF
--- a/postform_decoder/bindings/shared_types.hpp
+++ b/postform_decoder/bindings/shared_types.hpp
@@ -1,1 +1,0 @@
-../../libpostform/inc/postform/shared_types.hpp


### PR DESCRIPTION
This is not really needed anymore as the shared types were finally
removed.

Change-Id: I9df82e57f4770899f1a5d315c012a49373a9ef10