### PR TITLE
Add CLI option to disable FW version check

### DIFF
--- a/postform_decoder/src/lib.rs
+++ b/postform_decoder/src/lib.rs
@@ -100,7 +100,7 @@ pub struct Log {
 /// use std::path::Path;
 /// use postform_decoder::{Decoder, ElfMetadata};
 /// fn postform_example(file: &Path) {
-///     let elf_metadata = ElfMetadata::from_elf_file(file).unwrap();
+///     let elf_metadata = ElfMetadata::from_elf_file(file, false).unwrap();
 ///
 ///     // Get postform messages from the device
 ///     // This is just an example buffer, assume it comes from the target device
@@ -120,7 +120,7 @@ pub struct ElfMetadata {
 
 impl ElfMetadata {
     /// Attempts to instantiate the ElfMetadata struct from the provided ELF file.
-    pub fn from_elf_file(elf_path: &Path) -> Result<Self, Error> {
+    pub fn from_elf_file(elf_path: &Path, disable_version_check: bool) -> Result<Self, Error> {
         let file_contents = fs::read(elf_path)?;
         let elf_file = ElfFile::parse(&file_contents[..])?;
 
@@ -135,7 +135,7 @@ impl ElfMetadata {
                 .position(|&c| c == b'\0')
                 .unwrap_or(postform_version.len())],
         );
-        if postform_version != POSTFORM_VERSION {
+        if !disable_version_check && postform_version != POSTFORM_VERSION {
             return Err(Error::MismatchedPostformVersions(
                 postform_version.to_string(),
                 POSTFORM_VERSION.to_string(),

--- a/postform_persist/src/main.rs
+++ b/postform_persist/src/main.rs
@@ -23,6 +23,10 @@ struct Opts {
     #[structopt(name = "LOG_FILE", parse(from_os_str), required_unless_one(&["version"]))]
     log_file: Option<PathBuf>,
 
+    /// Disables FW version check.
+    #[structopt(long, short = "d")]
+    disable_version_check: bool,
+
     #[structopt(long, short = "V")]
     version: bool,
 }
@@ -39,7 +43,7 @@ fn main() -> Result<()> {
     }
 
     let elf_name = opts.elf.unwrap();
-    let elf_metadata = ElfMetadata::from_elf_file(&elf_name)?;
+    let elf_metadata = ElfMetadata::from_elf_file(&elf_name, opts.disable_version_check)?;
 
     let mut log_file = fs::File::open(opts.log_file.unwrap())?;
     let mut log_data = vec![];

--- a/postform_rtt/src/main.rs
+++ b/postform_rtt/src/main.rs
@@ -95,11 +95,11 @@ struct Opts {
     #[structopt(long, required_unless_one(&["list-chips", "list-probes", "version"]), env = "POSTFORM_CHIP")]
     chip: Option<String>,
 
-    /// The probe to open. The format is <VID>:<PID>[:<SERIAL>]
+    /// The probe to open. The format is <VID>:<PID>[:<SERIAL>].
     #[structopt(long, env = "POSTFORM_PROBE")]
     probe_selector: Option<DebugProbeSelector>,
 
-    /// Index of the probe to open. Can be obtained with --list-probes
+    /// Index of the probe to open. Can be obtained with --list-probes.
     #[structopt(long = "probe-index")]
     probe_index: Option<usize>,
 
@@ -107,8 +107,13 @@ struct Opts {
     #[structopt(name = "ELF", parse(from_os_str), required_unless_one(&["list-chips", "list-probes", "version"]))]
     elf: Option<PathBuf>,
 
+    /// Attaches to a running target instead of downloading the firmware.
     #[structopt(long, short)]
     attach: bool,
+
+    /// Disables FW version check.
+    #[structopt(long, short = "d")]
+    disable_version_check: bool,
 
     #[structopt(long, short = "V")]
     version: bool,
@@ -139,7 +144,7 @@ fn main() -> color_eyre::eyre::Result<()> {
     }
 
     let elf_name = opts.elf.unwrap();
-    let elf_metadata = ElfMetadata::from_elf_file(&elf_name)?;
+    let elf_metadata = ElfMetadata::from_elf_file(&elf_name, opts.disable_version_check)?;
 
     let probe = if let Some(probe_name) = opts.probe_selector {
         Probe::open(probe_name)?

--- a/postform_serial/src/main.rs
+++ b/postform_serial/src/main.rs
@@ -58,6 +58,10 @@ struct Opts {
     #[structopt(long, parse(try_from_str=try_to_serial_parity))]
     parity: Option<Parity>,
 
+    /// Disables FW version check.
+    #[structopt(long, short = "d")]
+    disable_version_check: bool,
+
     /// Lists the available serial ports and exits.
     #[structopt(long)]
     list_ports: bool,
@@ -87,7 +91,7 @@ fn main() -> color_eyre::eyre::Result<()> {
     }
 
     let elf_name = opts.elf.unwrap();
-    let elf_metadata = ElfMetadata::from_elf_file(&elf_name)?;
+    let elf_metadata = ElfMetadata::from_elf_file(&elf_name, opts.disable_version_check)?;
     let mut decoder = SerialDecoder::new(&elf_metadata);
 
     let mut port = serialport::new(opts.port.unwrap(), opts.baudrate.unwrap_or(115200u32))


### PR DESCRIPTION
Sometimes this is useful when the user knows that the transport format
is compatible regardless of a version difference in the binary.

In the future it would be nice if this information could be derived from
the semantic versioning, e.g.: FW with older minor should be compatible
with a more recent postform_decoder version and differences in patch
numbers should be ignored.

Currently that solution is not as useful because anything can change
before 1.0.0 as the API is not yet stable.

Change-Id: I8669151ede290bc290574d5bc41dbfdb4aced1a9