### PR TITLE
Make sure format_host builds with clang

### DIFF
--- a/app/build.mk
+++ b/app/build.mk
@@ -45,6 +45,8 @@ LOCAL_STATIC_LIBS := \
 include $(BUILD_BINARY)
 
 include $(CLEAR_VARS)
+CC := clang
+CXX := clang++
 LOCAL_NAME := format_host
 LOCAL_CFLAGS := $(POSTFORM_CFLAGS)
 LOCAL_CXXFLAGS := \


### PR DESCRIPTION
Since we track the linker script for this binary it cannot just build
with gcc, it should build with clang and use lld to ensure
compatibility.

Change-Id: I5a7229e4125c9e3e87cad04fb57748ccf0dc5de1