### PR TITLE
Add dependency on Ditto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ project(Postform)
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
 add_subdirectory(libpostform)
+
+include(cmake/ditto.cmake)
+
 if (POSTFORM_BUILD_EXAMPLES MATCHES "true")
   if (POSTFORM_BUILD_TARGET_APP MATCHES "true")
     include(cmake/cortex-m_hal.cmake)

--- a/cmake/ditto.cmake
+++ b/cmake/ditto.cmake
@@ -1,0 +1,8 @@
+include(FetchContent)
+
+FetchContent_Declare(
+  Ditto
+    GIT_REPOSITORY https://github.com/Javier-varez/ditto
+    GIT_TAG main)
+
+FetchContent_MakeAvailable(Ditto)

--- a/libpostform/CMakeLists.txt
+++ b/libpostform/CMakeLists.txt
@@ -16,6 +16,10 @@ add_library(postform STATIC
   src/platform.cpp
   src/rtt/transport.cpp)
 
+target_link_libraries(postform
+  PUBLIC
+  Ditto)
+
 target_compile_options(postform
   PRIVATE
     -Wall
@@ -59,6 +63,7 @@ if (POSTFORM_BUILD_UNITTESTS MATCHES "true")
     test/timestamp_mock.cpp)
 
   target_link_libraries(postform_tests
+    Ditto
     gtest_main
     gmock)
 

--- a/libpostform/inc/postform/file_logger.h
+++ b/libpostform/inc/postform/file_logger.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "ditto/badge.h"
 #include "postform/logger.h"
 
 namespace Postform {
@@ -41,21 +42,18 @@ class FileLogger : public Logger<FileLogger, FileWriter> {
   explicit FileLogger(std::string file_path);
   ~FileLogger();
 
- private:
-  std::atomic_bool m_taken{false};
-  int m_fd = -1;
-
-  FileWriter getWriter() {
+  FileWriter getWriter(Ditto::Badge<Logger<FileLogger, FileWriter>>) {
     if (!m_taken.exchange(true)) {
       return FileWriter{this, m_fd};
     }
     return FileWriter{};
   }
 
-  void release() { m_taken.store(false); }
+  void release(Ditto::Badge<FileWriter>) { m_taken.store(false); }
 
-  friend Logger<FileLogger, FileWriter>;
-  friend class FileWriter;
+ private:
+  std::atomic_bool m_taken{false};
+  int m_fd = -1;
 };
 
 }  // namespace Postform

--- a/libpostform/inc/postform/logger.h
+++ b/libpostform/inc/postform/logger.h
@@ -99,7 +99,7 @@ class Logger {
   void vlog(const Argument* arguments, std::size_t nargs) {
     uint64_t timestamp = getGlobalTimestamp();
 
-    Writer writer = static_cast<Derived&>(*this).getWriter();
+    Writer writer = static_cast<Derived&>(*this).getWriter({});
     writeLeb128(&writer, timestamp);
     for (std::size_t i = 0; i < nargs; i++) {
       switch (arguments[i].type) {

--- a/libpostform/src/file_logger.cpp
+++ b/libpostform/src/file_logger.cpp
@@ -19,7 +19,7 @@ void FileWriter::commit() {
     uint32_t size = m_data.size();
     [[maybe_unused]] uint32_t written = ::write(m_fd, &size, sizeof(size));
     written = ::write(m_fd, m_data.data(), m_data.size());
-    m_logger->release();
+    m_logger->release({});
     m_logger = nullptr;
     m_fd = -1;
   }


### PR DESCRIPTION
Since Ditto provides many useful and lightweight templates let's add it
as a dependency. This change uses Ditto::Badge to restrict possible
callers for the getWriter and release APIs in the SerialLogger and
FileLogger classes.