### PR TITLE
Only run clang tidy in pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,6 +88,7 @@ jobs:
 
   clang-tidy:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This build action doesn't seem to play well with a branch event, so we
should disable it.